### PR TITLE
Fix Makefile and desktop file + Russian translation

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -1,0 +1,67 @@
+# Russian translations for gtv-dvb package.
+# Copyright (C) 2017 THE gtv-dvb'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the gtv-dvb package.
+#  <antohami@altlinux.org>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gtv-dvb 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-20 17:24+0700\n"
+"PO-Revision-Date: 2017-11-20 17:24+0700\n"
+"Last-Translator:  <antohami@altlinux.org>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: src/gtv-dvb.c:707
+msgid "Channels"
+msgstr "Каналы"
+
+#: src/gtv-dvb.c:714
+msgid "Clear"
+msgstr "Очистить"
+
+#: src/gtv-dvb.c:712
+msgid "Down"
+msgstr "Вниз"
+
+#: src/gtv-dvb.c:718
+msgid "Full-screen"
+msgstr "Полный экран"
+
+#: src/gtv-dvb.c:719
+msgid "Mini"
+msgstr "Мини"
+
+#: src/gtv-dvb.c:717
+msgid "Mute"
+msgstr "Без звука"
+
+#: src/gtv-dvb.c:720
+msgid "Quit"
+msgstr "Выйти"
+
+#: src/gtv-dvb.c:703
+msgid "Record"
+msgstr "Запись"
+
+#: src/gtv-dvb.c:713
+msgid "Remove"
+msgstr "Удалить"
+
+#: src/gtv-dvb.c:708
+msgid "Scan"
+msgstr "Сканировать"
+
+#: src/gtv-dvb.c:704
+msgid "Stop"
+msgstr "Стоп"
+
+#: src/gtv-dvb.c:711
+msgid "Up"
+msgstr "Вверх"

--- a/res/gtv-dvb.desktop
+++ b/res/gtv-dvb.desktop
@@ -6,4 +6,4 @@ TryExec=bindir/gtv-dvb
 Exec=bindir/gtv-dvb %U
 Icon=display
 Terminal=false
-Categories=GTK;AudioVideo
+Categories=GTK;AudioVideo;Video


### PR DESCRIPTION
Пулл-рквест несёт:
1. Перевод на русский язык
2. Добавляет подкатегорию Video к desktop файлу
3. Добавляет в Makefile переменную CFLAG. Нужно чтоб майнтейнеры могли добавлять через неё дополнительные флаги к gcc, которые специфичны для каждого дистрибутива.
4. Иcправление make clean. Не отрабатывало удаление директории locale
5. Исправление make mergeinit. Совершенно логично, что mergeinit вызывает цель genpot. Зачем в терминале писать две команды, когда можно написать одну?
6. Исправление msgfmt. msgfmt не надо никаких переменных пердавать, ему достаточно собирать все po/*.po. Перенос mv был лишней операцией, как-то я сразу до этого не додумался...
7. При make нет необходимости вызывать translate, вполне достаточно msgfmt, т.е. сборки локалей.

P.s.: Желательно интернационализацию доделать. Английских фраз у вас в программе гораздо больше, чем сейчас в po. А после этого можно уже и официально релизиться. К отправке пакета в репозитории Альта у меня всё готово.